### PR TITLE
uname instead of hostname

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 
 # Domain is necessary to avoid debian installer to
 # require manual domain entry during the install.
-DOMAIN=`/bin/hostname -d` # Use domain of the host system
+DOMAIN=`/bin/uname -n` # Use domain of the host system
 #DOMAIN="dp-net.com" # Alternatively, hardcode domain
 # NB: See postinst.sh for ability to override domain received from
 # DHCP during the install.


### PR DESCRIPTION
`uname` in much more portable between MacOS
and differents GNU/Linux distros

`uname` is a GNU coreutils